### PR TITLE
將htmlentities改為htmlspecialchars

### DIFF
--- a/AioSDK/sdk/ECPay.Payment.Integration.php
+++ b/AioSDK/sdk/ECPay.Payment.Integration.php
@@ -609,7 +609,7 @@ abstract class ECPay_Aio
         $szHtml .=         "<form id=\"__ecpayForm\" method=\"post\" target=\"{$target}\" action=\"{$ServiceURL}\">";
 
         foreach ($arParameters as $keys => $value) {
-            $szHtml .=         "<input type=\"hidden\" name=\"{$keys}\" value=\"". htmlentities($value) . "\" />";
+            $szHtml .=         "<input type=\"hidden\" name=\"{$keys}\" value=\"". htmlspecialchars($value) . "\" />";
         }
 
         $szHtml .=             "<input type=\"hidden\" name=\"CheckMacValue\" value=\"{$szCheckMacValue}\" />";


### PR DESCRIPTION
使用htmlentities會連中文都做轉換，導致後續checkMacValue Error